### PR TITLE
fix: reuse the `metro.config.sourceExt` to determine source file type

### DIFF
--- a/src/data/MetroGraphSource.ts
+++ b/src/data/MetroGraphSource.ts
@@ -1,7 +1,8 @@
 import type metro from 'metro';
+import path from 'path';
 
 import type { StatsEntry, StatsModule, StatsSource } from './types';
-import { getNonBinaryContents } from '../utils/buffer';
+import { bufferIsUtf8 } from '../utils/buffer';
 import { getPackageNameFromPath } from '../utils/package';
 
 type MetroGraph = metro.Graph | metro.ReadOnlyGraph;
@@ -13,6 +14,10 @@ type ConvertGraphToStatsOptions = {
   preModules: Readonly<MetroModule[]>;
   graph: MetroGraph;
   options: Readonly<metro.SerializerOptions>;
+  extensions?: {
+    source?: Readonly<string[]>;
+    asset?: Readonly<string[]>;
+  };
 };
 
 export class MetroGraphSource implements StatsSource {
@@ -49,8 +54,8 @@ export class MetroGraphSource implements StatsSource {
 
 /** Convert a Metro graph instance to a JSON-serializable stats entry */
 export function convertGraph(options: ConvertGraphToStatsOptions): StatsEntry {
-  const serializeOptions = convertSerializeOptions(options.options);
-  const transformOptions = convertTransformOptions(options.graph.transformOptions);
+  const serializeOptions = convertSerializeOptions(options);
+  const transformOptions = convertTransformOptions(options);
   const platform =
     transformOptions?.customTransformOptions?.environment === 'node'
       ? 'server'
@@ -61,41 +66,46 @@ export function convertGraph(options: ConvertGraphToStatsOptions): StatsEntry {
     platform,
     projectRoot: options.projectRoot,
     entryPoint: options.entryPoint,
-    runtimeModules: options.preModules.map((module) => convertModule(options.graph, module)),
-    modules: collectEntryPointModules(options.graph, options.entryPoint),
+    runtimeModules: options.preModules.map((module) => convertModule(options, module)),
+    modules: collectEntryPointModules(options),
     serializeOptions,
     transformOptions,
   };
 }
 
 /** Find and collect all dependnecies related to the entrypoint within the graph */
-export function collectEntryPointModules(graph: MetroGraph, entryPoint: string) {
+export function collectEntryPointModules(
+  options: Pick<ConvertGraphToStatsOptions, 'graph' | 'entryPoint' | 'extensions'>
+) {
   const modules = new Map<string, StatsModule>();
 
   function discover(modulePath: string) {
-    const module = graph.dependencies.get(modulePath);
+    const module = options.graph.dependencies.get(modulePath);
 
     if (module && !modules.has(modulePath)) {
-      modules.set(modulePath, convertModule(graph, module));
+      modules.set(modulePath, convertModule(options, module));
       module.dependencies.forEach((modulePath) => discover(modulePath.absolutePath));
     }
   }
 
-  discover(entryPoint);
+  discover(options.entryPoint);
   return modules;
 }
 
 /** Convert a Metro module to a JSON-serializable stats module */
-export function convertModule(graph: MetroGraph, module: MetroModule): StatsModule {
+export function convertModule(
+  options: Pick<ConvertGraphToStatsOptions, 'graph' | 'extensions'>,
+  module: MetroModule
+): StatsModule {
   return {
     path: module.path,
     package: getPackageNameFromPath(module.path),
     size: module.output.reduce((bytes, output) => bytes + Buffer.byteLength(output.data.code), 0),
     imports: Array.from(module.dependencies.values()).map((module) => module.absolutePath),
     importedBy: Array.from(module.inverseDependencies).filter((dependecy) =>
-      graph.dependencies.has(dependecy)
+      options.graph.dependencies.has(dependecy)
     ),
-    source: getNonBinaryContents(module.getSource()) ?? '[binary file]',
+    source: getModuleSourceContent(options, module),
     output: module.output.map((output) => ({
       type: output.type,
       data: { code: output.data.code },
@@ -103,24 +113,53 @@ export function convertModule(graph: MetroGraph, module: MetroModule): StatsModu
   };
 }
 
+/**
+ * Attempt to load the source file content from module.
+ * If a file is an asset, it returns `[binary file]` instead.
+ */
+function getModuleSourceContent(
+  options: Pick<ConvertGraphToStatsOptions, 'extensions'>,
+  module: MetroModule
+) {
+  const fileExtension = path.extname(module.path).replace('.', '');
+
+  if (options.extensions?.source?.includes(fileExtension)) {
+    return module.getSource().toString();
+  }
+
+  if (options.extensions?.asset?.includes(fileExtension)) {
+    return '[binary file]';
+  }
+
+  if (module.path.includes('?ctx')) {
+    return module.getSource().toString();
+  }
+
+  if (bufferIsUtf8(module.getSource())) {
+    return module.getSource().toString();
+  }
+
+  return '[binary file]';
+}
+
 /** Convert Metro transform options to a JSON-serializable object */
 export function convertTransformOptions(
-  transformer: metro.TransformInputOptions
+  options: Pick<ConvertGraphToStatsOptions, 'graph'>
 ): StatsEntry['transformOptions'] {
-  return transformer;
+  return options.graph.transformOptions ?? {};
 }
 
 /** Convert Metro serialize options to a JSON-serializable object */
 export function convertSerializeOptions(
-  serializer: metro.SerializerOptions
+  options: Pick<ConvertGraphToStatsOptions, 'options'>
 ): StatsEntry['serializeOptions'] {
-  const options: StatsEntry['serializeOptions'] = { ...serializer };
+  const serializeOptions: StatsEntry['serializeOptions'] = { ...options.options };
 
   // Delete all filters
-  delete options['processModuleFilter'];
-  delete options['createModuleId'];
-  delete options['getRunModuleStatement'];
-  delete options['shouldAddToIgnoreList'];
+  delete serializeOptions['processModuleFilter'];
+  delete serializeOptions['createModuleId'];
+  delete serializeOptions['getRunModuleStatement'];
+  delete serializeOptions['shouldAddToIgnoreList'];
 
-  return options;
+  return serializeOptions;
 }

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -1,7 +1,7 @@
 /** Characters outside the UTF8 range, if matched the file is likely binary */
 const NON_UTF8_PATTERN = /[^\u0000-\u007F]/;
 
-export function getNonBinaryContents(buffer: Buffer) {
-  const contents = buffer.toString();
-  return NON_UTF8_PATTERN.test(contents) ? '[binary file]' : contents;
+/** Estimate if the buffer content is text-based */
+export function bufferIsUtf8(buffer: Buffer) {
+  return NON_UTF8_PATTERN.test(buffer.toString());
 }

--- a/src/withExpoAtlas.ts
+++ b/src/withExpoAtlas.ts
@@ -34,6 +34,10 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
   }
 
   const statsFile = options?.statsFile ?? getStatsPath(projectRoot);
+  const extensions = {
+    source: config.resolver?.sourceExts,
+    asset: config.resolver?.assetExts,
+  };
 
   // Note(cedric): we don't have to await this, Metro would never bundle before this is finisheds
   createStatsFile(statsFile);
@@ -43,7 +47,7 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
     // Note(cedric): we don't have to await this, it has a built-in write queue
     writeStatsEntry(
       statsFile,
-      convertGraph({ projectRoot, entryPoint, preModules, graph, options })
+      convertGraph({ projectRoot, entryPoint, preModules, graph, options, extensions })
     );
 
     return originalSerializer(entryPoint, preModules, graph, options);


### PR DESCRIPTION
### Linked issue
Reuse Metro's `sourceExt` and `assetExt` to determine if Atlas should include the original source code.
