### PR TITLE
feature: add `--no-open` flag to skip opening browser automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "types": "build/src/index.d.ts",
   "files": [
     "build",
+    "!build/tsconfig.tsbuildinfo",
     "expo-module.config.json",
     "metro.js",
     "metro.d.ts",

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -13,6 +13,7 @@ const args = arg({
   '--help': Boolean,
   '--port': Number,
   '--version': Boolean,
+  '--no-open': Boolean,
   // Aliases
   '-h': '--help',
   '-p': '--port',
@@ -31,6 +32,7 @@ if (args['--help']) {
 
     Options
       --port, -p      Port to listen on
+      --no-open       Do not open the browser automatically
       --help, -h      Displays this message
       --version, -v   Displays the current version
   `);
@@ -51,9 +53,11 @@ async function run() {
     console.log('Loaded stats file:');
     console.log(`  ${options.statsFile}`);
 
-    open(href).catch((error) => {
-      console.error('Could not automatically open browser:', error.message);
-    });
+    if (options.browserOpen) {
+      open(href).catch((error) => {
+        console.error('Could not automatically open browser:', error.message);
+      });
+    }
   });
 }
 

--- a/src/cli/resolveOptions.ts
+++ b/src/cli/resolveOptions.ts
@@ -9,7 +9,7 @@ export type Options = Awaited<ReturnType<typeof resolveOptions>>;
 export async function resolveOptions(input: Input) {
   const statsFile = await resolveStatsFile(input);
   const port = await resolvePort(input);
-  return { statsFile, port };
+  return { statsFile, port, browserOpen: input['--no-open'] !== false };
 }
 
 async function resolveStatsFile(input: Input) {


### PR DESCRIPTION
### Linked issue
When testing a couple of things, its annoying to keep all these tabs open
