### PR TITLE
feature: add typecheck scripts and change `~plugin/` shared code reference

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  core:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
@@ -24,7 +24,13 @@ jobs:
       - name: 🚨 Lint core
         run: bun run lint -- --max-warnings 0
 
-  build:
+      - name: 📋 Typecheck core
+        run: bun run typecheck
+
+      - name: 👷 Build core
+        run: bun run build
+
+  webui:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
@@ -35,8 +41,9 @@ jobs:
         with:
           with-webui: true
 
-      - name: 👷 Build core
-        run: bun run build
+      - name: 📋 Typecheck webui
+        run: bun run typecheck
+        working-directory: webui
 
       - name: 👷 Build webui
         run: bun run build

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           with-webui: true
 
+      # Required for typechecking webui
+      - name: 👷 Build core
+        run: bun run build
+
       - name: 📋 Typecheck webui
         run: bun run typecheck
         working-directory: webui

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "url": "https://github.com/byCedric/expo-atlas"
   },
   "scripts": {
-    "lint": "eslint . --ext js,ts,tsx",
     "build": "expo-module build",
-    "clean": "expo-module clean"
+    "clean": "expo-module clean",
+    "lint": "eslint . --ext js,ts,tsx",
+    "typecheck": "expo-module typecheck"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,6 +1,9 @@
 import { StatsSource } from '../data/types';
 
 declare global {
-  /** The globally initialized data source for Atlas */
+  /**
+   * The globally initialized data source for Atlas.
+   * This is set in a global to access the data from the bundled webui API routes.
+   */
   var EXPO_ATLAS_SOURCE: StatsSource; // eslint-disable-line no-var
 }

--- a/webui/package.json
+++ b/webui/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "build": "expo export --platform web"
+    "build": "expo export --platform web",
+    "typecheck": "expo-module typecheck"
   },
   "dependencies": {
     "@expo/styleguide": "^8.2.2",

--- a/webui/src/app/api/stats/[entry]/modules/index+api.ts
+++ b/webui/src/app/api/stats/[entry]/modules/index+api.ts
@@ -1,6 +1,7 @@
 import { filtersFromUrlParams } from '~/providers/modules';
 import { getSource } from '~/utils/atlas';
-import { fuzzyFilterModules, type StatsEntry, type StatsModule } from '~plugin';
+import { type StatsEntry, type StatsModule } from '~core/data/types';
+import { fuzzyFilterModules } from '~core/utils/search';
 
 /** The partial module data, when listing all available modules from a stats entry */
 export type ModuleMetadata = Omit<StatsModule, 'source' | 'output'> & {

--- a/webui/src/app/modules/[path].tsx
+++ b/webui/src/app/modules/[path].tsx
@@ -7,7 +7,7 @@ import { PageHeader, PageTitle } from '~/ui/Page';
 import { Skeleton } from '~/ui/Skeleton';
 import { Tag } from '~/ui/Tag';
 import { formatFileSize } from '~/utils/formatString';
-import { PartialStatsEntry, StatsModule } from '~plugin';
+import { type PartialStatsEntry, type StatsModule } from '~core/data/types';
 
 export default function ModulePage() {
   const { entryId, entry } = useStatsEntryContext();

--- a/webui/src/providers/stats.tsx
+++ b/webui/src/providers/stats.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { type PropsWithChildren, createContext, useContext, useMemo, useState } from 'react';
 
-import { type PartialStatsEntry } from '~plugin';
+import { type PartialStatsEntry } from '~core/data/types';
 
 type StatsEntryContext = {
   entryId: string;

--- a/webui/src/ui/Checkbox.tsx
+++ b/webui/src/ui/Checkbox.tsx
@@ -2,10 +2,9 @@
 
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import cn from 'classnames';
+// @ts-expect-error
 import CheckIcon from 'lucide-react/dist/esm/icons/check';
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react';
-
-// @ts-expect-error
 
 export const Checkbox = forwardRef<
   ElementRef<typeof CheckboxPrimitive.Root>,

--- a/webui/src/utils/atlas.ts
+++ b/webui/src/utils/atlas.ts
@@ -1,4 +1,4 @@
-import { type StatsSource } from '~plugin';
+import { type StatsSource } from '~core/data/types';
 
 declare global {
   var EXPO_ATLAS_SOURCE: StatsSource; // eslint-disable-line no-var

--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -6,7 +6,7 @@
       "~/*": [
         "./src/*"
       ],
-      "~plugin": ["../src"]
+      "~plugin/*": ["../src/*"]
     }
   },
   "references": [

--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -6,7 +6,7 @@
       "~/*": [
         "./src/*"
       ],
-      "~plugin/*": ["../src/*"]
+      "~core/*": ["../src/*"]
     }
   },
   "references": [


### PR DESCRIPTION
### Linked issue
Let webui import only what's necessary from the shared code. It helps reducing duplicated/bundled code in webui.