### PR TITLE
refactor: drop `expo-atlas/middleware` entry point

### DIFF
--- a/middleware.d.ts
+++ b/middleware.d.ts
@@ -1,1 +1,0 @@
-export * from './build/src/middleware';

--- a/middleware.js
+++ b/middleware.js
@@ -1,1 +1,0 @@
-module.exports = require('./build/src/middleware.js');

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "expo-module.config.json",
     "metro.js",
     "metro.d.ts",
-    "middleware.js",
-    "middleware.d.js",
     "webui/dist"
   ],
   "homepage": "https://github.com/byCedric/expo-atlas",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import './utils/global';
 
 export type * from './data/types';
-
 export { MetroGraphSource } from './data/MetroGraphSource';
 export { StatsFileSource } from './data/StatsFileSource';
 
 export { AtlasError, AtlasValidationError } from './utils/errors';
-export { createStatsFile, validateStatsFile, getStatsMetdata, getStatsPath } from './utils/stats';
+export { createAtlasMiddleware } from './utils/middleware';
 export { fuzzyFilterModules } from './utils/search';
+export { createStatsFile, validateStatsFile, getStatsMetdata, getStatsPath } from './utils/stats';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,2 +1,0 @@
-export { MetroGraphSource } from './data/MetroGraphSource';
-export { createAtlasMiddleware } from './utils/middleware';


### PR DESCRIPTION
### Linked issue
Now that the webui is only importing what it needs, we can revert back to the main entry point for things like the middleware.
