### PR TITLE
chore: restore webui metro cache in ci

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -36,3 +36,13 @@ runs:
       run: bun install
       working-directory: webui
       shell: bash
+
+    - name: ♻️ Restore webui cache
+      if: ${{ inputs.with-webui == 'true' }}
+      uses: actions/cache@v4
+      with:
+        key: webui-metro-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          webui-metro-${{ runner.os }}
+        path: |
+          webui/node_modules/.cache/metro

--- a/webui/metro.config.js
+++ b/webui/metro.config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig } = require('expo/metro-config');
+const { FileStore } = require('metro-cache');
 const { withNativeWind } = require('nativewind/metro');
 const path = require('path');
 
@@ -6,6 +7,11 @@ const config = withNativeWind(getDefaultConfig(__dirname), {
   input: './src/styles.css',
 });
 
+// Allow Metro to access the `~plugin/**` files
 config.watchFolders = [__dirname, path.resolve(__dirname, '..')];
+// Move the Metro cache to `node_modules/.cache`
+config.cacheStores = [
+  new FileStore({ root: path.join(__dirname, 'node_modules', '.cache', 'metro') }),
+];
 
 module.exports = config;

--- a/webui/metro.config.js
+++ b/webui/metro.config.js
@@ -9,6 +9,7 @@ const config = withNativeWind(getDefaultConfig(__dirname), {
 
 // Allow Metro to access the `~plugin/**` files
 config.watchFolders = [__dirname, path.resolve(__dirname, '..')];
+
 // Move the Metro cache to `node_modules/.cache`
 config.cacheStores = [
   new FileStore({ root: path.join(__dirname, 'node_modules', '.cache', 'metro') }),


### PR DESCRIPTION
### Linked issue
Should help make CI a bit faster.

before | after
--- | ---
![no-cache](https://github.com/byCedric/expo-atlas/assets/1203991/a7b42170-11f4-46ca-8429-f51a287bacb7) | ![with-cache](https://github.com/byCedric/expo-atlas/assets/1203991/ca6a47a3-5897-46a2-ba67-df093576df22)