### PR TITLE
refactor: solidify the exported atlas file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install the `expo-atlas` package as (development) dependency to your project:
 $ npx expo install expo-atlas
 ```
 
-Configure your Metro config to emit a `.expo/stats.jsonl` file containing information about your bundles.
+Configure your Metro config to emit an Atlas file containing information about your bundles.
 
 ```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');
@@ -36,12 +36,12 @@ $ npx expo export --platform all
 $ npx expo-atlas
 ```
 
-## 🧑‍🤝‍🧑 Sharing stats files
+## 🧑‍🤝‍🧑 Sharing the Atlas file
 
-You can also open a previously created `stats.jsonl` file:
+You can also open a previously created `atlas.jsonl` file:
 
 ```
-$ npx expo-atlas ./path/to/stats.jsonl
+$ npx expo-atlas ./path/to/atlas.jsonl
 ```
 
 <div align="center">

--- a/src/utils/__tests__/stats.test.ts
+++ b/src/utils/__tests__/stats.test.ts
@@ -7,8 +7,8 @@ import { AtlasValidationError } from '../errors';
 import { getStatsPath, getStatsMetdata, createStatsFile, validateStatsFile } from '../stats';
 
 describe('getStatsPath', () => {
-  it('returns default path `<project>/.expo/stats.jsonl`', () => {
-    expect(getStatsPath('<project>')).toBe('<project>/.expo/stats.jsonl');
+  it('returns default path `<project>/.expo/atlas.jsonl`', () => {
+    expect(getStatsPath('<project>')).toBe('<project>/.expo/atlas.jsonl');
   });
 });
 

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -10,7 +10,7 @@ export type StatsMetadata = { name: string; version: string };
 
 /** The default location of the metro stats file */
 export function getStatsPath(projectRoot: string) {
-  return path.join(projectRoot, '.expo/stats.jsonl');
+  return path.join(projectRoot, '.expo/atlas.jsonl');
 }
 
 /** The information to validate if a stats file is compatible with this library version */


### PR DESCRIPTION
### Linked issue
Solidy the exported file format. Might want to add support for brotli / gzip compressing too, as that will drastically downplay the size. When doing so, double-check if the decompress performance doesn't hurt too much.