### PR TITLE
refactor: use url-safe ids for `MetroGraphSource`

### DIFF
--- a/src/data/MetroGraphSource.ts
+++ b/src/data/MetroGraphSource.ts
@@ -62,7 +62,7 @@ export function convertGraph(options: ConvertGraphToStatsOptions): StatsEntry {
       : transformOptions?.platform ?? 'unknown';
 
   return {
-    id: `${options.entryPoint}+${platform}`,
+    id: Buffer.from(`${options.entryPoint}+${platform}`).toString('base64'), // FIX: only use URL allowed characters
     platform,
     projectRoot: options.projectRoot,
     entryPoint: options.entryPoint,


### PR DESCRIPTION
### Linked issue
This is a slight oversight in the webui, where we treat these stats entry ids as URL safe. We can revisit later though.