### PR TITLE
refactor(cli): always overwrite atlas file

### DIFF
--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -40,14 +40,7 @@ export async function validateStatsFile(statsFile: string, metadata = getStatsMe
  * This metdata is used by the API to determine version compatibility.
  */
 export async function createStatsFile(filePath: string) {
-  if (fs.existsSync(filePath)) {
-    try {
-      return await validateStatsFile(filePath);
-    } catch {
-      await fs.promises.writeFile(filePath, '');
-    }
-  }
-
   await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.promises.rm(filePath, { force: true });
   await appendJsonLine(filePath, getStatsMetdata());
 }


### PR DESCRIPTION
### Linked issue
This was something we added as workaround due to serialization issues when running `expo export --platform all`, we had to resort to `expo export --platform android && expo export --platform ios`.

Now that the serialization issues are solved, let's revert this workaround and only write the stats from the latest `expo export` call.
