### PR TITLE
fix: use `sharedRoot` for monorepo projects

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,7 @@ export function createExpoAtlasMiddleware(config: MetroConfig) {
       graph,
       options,
       extensions: metroExtensions,
+      watchFolders: config.watchFolders,
     });
 
     return metroCustomSerializer(entryPoint, preModules, graph, options);

--- a/src/data/AtlasFileSource.ts
+++ b/src/data/AtlasFileSource.ts
@@ -39,20 +39,20 @@ export class AtlasFileSource implements AtlasSource {
  * This only reads the bundle name, and adds a line number as ID.
  */
 export async function listAtlasEntries(filePath: string) {
-  const bundlePattern = /^\["([^"]+)","([^"]+)","([^"]+),"([^"]+)/;
+  const bundlePattern = /^\["([^"]+)","([^"]+)","([^"]+)","([^"]+)"/;
   const entries: PartialAtlasEntry[] = [];
 
   await forEachJsonLines(filePath, (contents, line) => {
     // Skip the metadata line
     if (line === 1) return;
 
-    const [_, platform, projectRoot, serverRoot, entryPoint] = contents.match(bundlePattern) ?? [];
-    if (platform && projectRoot && serverRoot && entryPoint) {
+    const [_, platform, projectRoot, sharedRoot, entryPoint] = contents.match(bundlePattern) ?? [];
+    if (platform && projectRoot && sharedRoot && entryPoint) {
       entries.push({
         id: String(line),
         platform: platform as any,
         projectRoot,
-        serverRoot,
+        sharedRoot,
         entryPoint,
       });
     }
@@ -70,7 +70,7 @@ export async function readAtlasEntry(filePath: string, id: number): Promise<Atla
     id: String(id),
     platform: atlasEntry[0],
     projectRoot: atlasEntry[1],
-    serverRoot: atlasEntry[2],
+    sharedRoot: atlasEntry[2],
     entryPoint: atlasEntry[3],
     runtimeModules: atlasEntry[4],
     modules: new Map(atlasEntry[5].map((module) => [module.path, module])),
@@ -90,7 +90,7 @@ export function writeAtlasEntry(filePath: string, entry: AtlasEntry) {
   const line = [
     entry.platform,
     entry.projectRoot,
-    entry.serverRoot,
+    entry.sharedRoot,
     entry.entryPoint,
     entry.runtimeModules,
     Array.from(entry.modules.values()),

--- a/src/data/AtlasFileSource.ts
+++ b/src/data/AtlasFileSource.ts
@@ -39,19 +39,20 @@ export class AtlasFileSource implements AtlasSource {
  * This only reads the bundle name, and adds a line number as ID.
  */
 export async function listAtlasEntries(filePath: string) {
-  const bundlePattern = /^\["([^"]+)","([^"]+)","([^"]+)/;
+  const bundlePattern = /^\["([^"]+)","([^"]+)","([^"]+),"([^"]+)/;
   const entries: PartialAtlasEntry[] = [];
 
   await forEachJsonLines(filePath, (contents, line) => {
     // Skip the metadata line
     if (line === 1) return;
 
-    const [_, platform, projectRoot, entryPoint] = contents.match(bundlePattern) ?? [];
-    if (platform && projectRoot && entryPoint) {
+    const [_, platform, projectRoot, serverRoot, entryPoint] = contents.match(bundlePattern) ?? [];
+    if (platform && projectRoot && serverRoot && entryPoint) {
       entries.push({
         id: String(line),
         platform: platform as any,
         projectRoot,
+        serverRoot,
         entryPoint,
       });
     }
@@ -69,11 +70,12 @@ export async function readAtlasEntry(filePath: string, id: number): Promise<Atla
     id: String(id),
     platform: atlasEntry[0],
     projectRoot: atlasEntry[1],
-    entryPoint: atlasEntry[2],
-    runtimeModules: atlasEntry[3],
-    modules: new Map(atlasEntry[4].map((module) => [module.path, module])),
-    transformOptions: atlasEntry[5],
-    serializeOptions: atlasEntry[6],
+    serverRoot: atlasEntry[2],
+    entryPoint: atlasEntry[3],
+    runtimeModules: atlasEntry[4],
+    modules: new Map(atlasEntry[5].map((module) => [module.path, module])),
+    transformOptions: atlasEntry[6],
+    serializeOptions: atlasEntry[7],
   };
 }
 
@@ -88,6 +90,7 @@ export function writeAtlasEntry(filePath: string, entry: AtlasEntry) {
   const line = [
     entry.platform,
     entry.projectRoot,
+    entry.serverRoot,
     entry.entryPoint,
     entry.runtimeModules,
     Array.from(entry.modules.values()),

--- a/src/data/MetroGraphSource.ts
+++ b/src/data/MetroGraphSource.ts
@@ -139,6 +139,7 @@ export function convertGraph(options: ConvertGraphToAtlasOptions): AtlasEntry {
     id: Buffer.from(`${options.entryPoint}+${platform}`).toString('base64url'), // FIX: only use URL allowed characters
     platform,
     projectRoot: options.projectRoot,
+    serverRoot: options.options.serverRoot,
     entryPoint: options.entryPoint,
     runtimeModules: options.preModules.map((module) => convertModule(options, module)),
     modules: collectEntryPointModules(options),

--- a/src/data/MetroGraphSource.ts
+++ b/src/data/MetroGraphSource.ts
@@ -38,6 +38,7 @@ export class MetroGraphSource implements AtlasSource {
       id: item.entry.id,
       platform: item.entry.platform,
       projectRoot: item.entry.projectRoot,
+      serverRoot: item.entry.serverRoot,
       entryPoint: item.entry.entryPoint,
     }));
   }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -11,7 +11,10 @@ export interface AtlasSource {
   entryDeltaEnabled(): boolean;
 }
 
-export type PartialAtlasEntry = Pick<AtlasEntry, 'id' | 'platform' | 'projectRoot' | 'entryPoint'>;
+export type PartialAtlasEntry = Pick<
+  AtlasEntry,
+  'id' | 'platform' | 'projectRoot' | 'serverRoot' | 'entryPoint'
+>;
 
 export type AtlasEntry = {
   /** The unique reference or ID to this entry */
@@ -20,6 +23,8 @@ export type AtlasEntry = {
   platform: 'android' | 'ios' | 'web' | 'server';
   /** The absolute path to the root of the project */
   projectRoot: string;
+  /** The absolute path to the shared root of all imported modules */
+  serverRoot: string;
   /** The absolute path to the entry point used when creating the bundle */
   entryPoint: string;
   /** All known modules that are prepended for the runtime itself */

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -13,7 +13,7 @@ export interface AtlasSource {
 
 export type PartialAtlasEntry = Pick<
   AtlasEntry,
-  'id' | 'platform' | 'projectRoot' | 'serverRoot' | 'entryPoint'
+  'id' | 'platform' | 'projectRoot' | 'sharedRoot' | 'entryPoint'
 >;
 
 export type AtlasEntry = {
@@ -24,7 +24,7 @@ export type AtlasEntry = {
   /** The absolute path to the root of the project */
   projectRoot: string;
   /** The absolute path to the shared root of all imported modules */
-  serverRoot: string;
+  sharedRoot: string;
   /** The absolute path to the entry point used when creating the bundle */
   entryPoint: string;
   /** All known modules that are prepended for the runtime itself */

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -33,6 +33,7 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
   }
 
   const atlasFile = options?.atlasFile ?? getAtlasPath(projectRoot);
+  const watchFolders = config.watchFolders;
   const extensions = {
     source: config.resolver?.sourceExts,
     asset: config.resolver?.assetExts,
@@ -46,7 +47,15 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
     // Note(cedric): we don't have to await this, it has a built-in write queue
     writeAtlasEntry(
       atlasFile,
-      convertGraph({ projectRoot, entryPoint, preModules, graph, options, extensions })
+      convertGraph({
+        projectRoot,
+        entryPoint,
+        preModules,
+        graph,
+        options,
+        extensions,
+        watchFolders,
+      })
     );
 
     return originalSerializer(entryPoint, preModules, graph, options);

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,29 @@
+/**
+ * Find the shared root of all paths.
+ * This will split all paths by segments and find the longest common prefix.
+ */
+export function findSharedRoot(paths: string[]) {
+  if (!paths.length) {
+    return null;
+  }
+
+  let sharedRoot: string[] = [];
+
+  for (const item of paths) {
+    const segments = item.split('/');
+
+    if (!sharedRoot.length) {
+      sharedRoot = segments;
+      continue;
+    }
+
+    for (let i = 0; i < sharedRoot.length; i++) {
+      if (sharedRoot[i] !== segments[i]) {
+        sharedRoot = sharedRoot.slice(0, i);
+        break;
+      }
+    }
+  }
+
+  return sharedRoot.join('/');
+}

--- a/webui/src/app/(atlas)/[entry]/folders/[path].tsx
+++ b/webui/src/app/(atlas)/[entry]/folders/[path].tsx
@@ -10,6 +10,7 @@ import { PropertySummary } from '~/components/PropertySummary';
 import { StateInfo } from '~/components/StateInfo';
 import { EntryDeltaToast, useEntry } from '~/providers/entries';
 import { Layout, LayoutHeader, LayoutNavigation, LayoutTitle } from '~/ui/Layout';
+import { Spinner } from '~/ui/Spinner';
 import { Tag } from '~/ui/Tag';
 import { fetchApi } from '~/utils/api';
 import { type ModuleFilters, useModuleFilters, moduleFiltersToParams } from '~/utils/filters';
@@ -46,7 +47,11 @@ export default function FolderPage() {
         <ModuleFiltersForm disableNodeModules />
       </LayoutHeader>
       <EntryDeltaToast entryId={entry.id} />
-      {modules.isError ? (
+      {modules.isPending && !modules.isPlaceholderData ? (
+        <StateInfo>
+          <Spinner />
+        </StateInfo>
+      ) : modules.isError ? (
         <StateInfo title="Failed to generate graph.">
           Try restarting Expo Atlas. If this error keeps happening, open a bug report.
         </StateInfo>

--- a/webui/src/app/(atlas)/[entry]/folders/[path].tsx
+++ b/webui/src/app/(atlas)/[entry]/folders/[path].tsx
@@ -31,18 +31,20 @@ export default function FolderPage() {
       <LayoutHeader>
         <LayoutTitle>
           <BreadcrumbLinks entry={entry} path={absolutePath!} />
-          {!!modules.data && (
-            <PropertySummary>
-              <Tag variant={entry.platform} />
-              <span>folder</span>
+          <PropertySummary>
+            <Tag variant={entry.platform} />
+            <span>folder</span>
+            {!!modules.data?.filtered.moduleFiles && (
               <span>
                 {modules.data.filtered.moduleFiles === 1
                   ? `${modules.data.filtered.moduleFiles} module`
                   : `${modules.data.filtered.moduleFiles} modules`}
               </span>
+            )}
+            {!!modules.data?.filtered.moduleSize && (
               <span>{formatFileSize(modules.data.filtered.moduleSize)}</span>
-            </PropertySummary>
-          )}
+            )}
+          </PropertySummary>
         </LayoutTitle>
         <ModuleFiltersForm disableNodeModules />
       </LayoutHeader>

--- a/webui/src/app/(atlas)/[entry]/index.tsx
+++ b/webui/src/app/(atlas)/[entry]/index.tsx
@@ -28,12 +28,12 @@ export default function BundlePage() {
       <LayoutHeader>
         <LayoutTitle>
           <h1 className="text-lg font-bold mr-8">Bundle</h1>
-          {!!modules.data && (
-            <PropertySummary>
-              <Tag variant={entry.platform} />
-              <span>{modules.data.entry.moduleFiles} modules</span>
-              <span>{formatFileSize(modules.data.entry.moduleSize)}</span>
-              {modules.data.filtered.moduleFiles !== modules.data.entry.moduleFiles && (
+          <PropertySummary>
+            <Tag variant={entry.platform} />
+            {!!modules.data && <span>{modules.data.entry.moduleFiles} modules</span>}
+            {!!modules.data && <span>{formatFileSize(modules.data.entry.moduleSize)}</span>}
+            {modules.data &&
+              modules.data.filtered.moduleFiles !== modules.data.entry.moduleFiles && (
                 <PropertySummary
                   className="text-tertiary italic"
                   prefix={<span className="select-none mr-2">visible:</span>}
@@ -42,8 +42,7 @@ export default function BundlePage() {
                   <span>{formatFileSize(modules.data.filtered.moduleSize)}</span>
                 </PropertySummary>
               )}
-            </PropertySummary>
-          )}
+          </PropertySummary>
         </LayoutTitle>
         <ModuleFiltersForm />
       </LayoutHeader>

--- a/webui/src/app/(atlas)/[entry]/modules/[path].tsx
+++ b/webui/src/app/(atlas)/[entry]/modules/[path].tsx
@@ -28,14 +28,12 @@ export default function ModulePage() {
       <LayoutHeader>
         <LayoutTitle>
           <BreadcrumbLinks entry={entry} path={absolutePath!} />
-          {!!module.data && (
-            <PropertySummary>
-              <Tag variant={entry.platform} />
-              {!!module.data.package && <span>{module.data.package}</span>}
-              <span>{getModuleType(module.data)}</span>
-              <span>{formatFileSize(module.data.size)}</span>
-            </PropertySummary>
-          )}
+          <PropertySummary>
+            <Tag variant={entry.platform} />
+            {!!module.data?.package && <span>{module.data.package}</span>}
+            {!!module.data && <span>{getModuleType(module.data)}</span>}
+            {!!module.data && <span>{formatFileSize(module.data.size)}</span>}
+          </PropertySummary>
         </LayoutTitle>
       </LayoutHeader>
       <EntryDeltaToast entryId={entry.id} modulePath={absolutePath} />

--- a/webui/src/app/(atlas)/[entry]/modules/[path].tsx
+++ b/webui/src/app/(atlas)/[entry]/modules/[path].tsx
@@ -11,7 +11,7 @@ import { Layout, LayoutHeader, LayoutNavigation, LayoutTitle } from '~/ui/Layout
 import { Skeleton } from '~/ui/Skeleton';
 import { Tag } from '~/ui/Tag';
 import { fetchApi } from '~/utils/api';
-import { relativeEntryPath } from '~/utils/entry';
+import { relativeBundlePath } from '~/utils/bundle';
 import { formatFileSize } from '~/utils/formatString';
 import { type AtlasModule } from '~core/data/types';
 
@@ -62,7 +62,7 @@ export default function ModulePage() {
                         params: { entry: entry.id, path },
                       }}
                     >
-                      {relativeEntryPath(entry, path)}
+                      {relativeBundlePath(entry, path)}
                     </Link>
                   </li>
                 ))}

--- a/webui/src/components/BreadcrumbLinks.tsx
+++ b/webui/src/components/BreadcrumbLinks.tsx
@@ -9,7 +9,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '~/ui/Breadcrumb';
-import { relativeEntryPath } from '~/utils/entry';
+import { relativeBundlePath } from '~/utils/bundle';
 import { type PartialAtlasEntry } from '~core/data/types';
 
 type BreadcrumbLinksProps = {
@@ -61,7 +61,7 @@ type BreadcrumbLinkItem = {
 };
 
 function getBreadcrumbLinks(props: BreadcrumbLinksProps): BreadcrumbLinkItem[] {
-  const relativePath = relativeEntryPath(props.entry, props.path);
+  const relativePath = relativeBundlePath(props.entry, props.path);
 
   return relativePath.split('/').map((label, index, breadcrumbs) => {
     const isLastSegment = index === breadcrumbs.length - 1;

--- a/webui/src/components/BreadcrumbLinks.tsx
+++ b/webui/src/components/BreadcrumbLinks.tsx
@@ -67,8 +67,6 @@ function getBreadcrumbLinks(props: BreadcrumbLinksProps): BreadcrumbLinkItem[] {
   const rootPath = rootBundlePath(props.entry).replace(/\/$/, '');
   const relativePath = relativeBundlePath(props.entry, props.path).replace(/^\//, '');
 
-  console.log({ rootPath, relativePath });
-
   return relativePath.split('/').map((label, index, breadcrumbs) => {
     const isLastSegment = index === breadcrumbs.length - 1;
     const breadcrumb: BreadcrumbLinkItem = { key: `${index}-${label}`, label };

--- a/webui/src/components/BundleGraph.tsx
+++ b/webui/src/components/BundleGraph.tsx
@@ -122,7 +122,7 @@ function getBundleGraphSeries(graph: TreemapNode): TreemapSeriesOption {
       {
         itemStyle: {
           color: '#37434A',
-          borderColorSaturation: 0.18,
+          borderColorSaturation: 0.15,
           colorSaturation: 0.25,
           borderWidth: 4,
         },

--- a/webui/src/components/BundleSelectForm.tsx
+++ b/webui/src/components/BundleSelectForm.tsx
@@ -9,7 +9,7 @@ import ChevronUpIcon from 'lucide-react/dist/esm/icons/chevron-up';
 import { useEntry } from '~/providers/entries';
 import { Button } from '~/ui/Button';
 import { Tag } from '~/ui/Tag';
-import { relativeEntryPath } from '~/utils/entry';
+import { relativeBundlePath } from '~/utils/bundle';
 
 export function BundleSelectForm() {
   const router = useRouter();
@@ -45,7 +45,7 @@ export function BundleSelectForm() {
                 <Select.Item value={item.id} asChild>
                   <Button variant="quaternary" size="sm" className="w-full">
                     <Tag variant={item.platform} className="mr-2" />
-                    <Select.ItemText>{relativeEntryPath(entry, item.entryPoint)}</Select.ItemText>
+                    <Select.ItemText>{relativeBundlePath(entry, item.entryPoint)}</Select.ItemText>
                   </Button>
                 </Select.Item>
               </div>

--- a/webui/src/ui/Layout.tsx
+++ b/webui/src/ui/Layout.tsx
@@ -15,22 +15,33 @@ const layoutVariants = cva('', {
   },
 });
 
-export function Layout(props: PropsWithChildren<VariantProps<typeof layoutVariants>>) {
-  const { variant, children, ...rest } = props;
-
+export function Layout({
+  variant,
+  className,
+  children,
+  ...props
+}: PropsWithChildren<VariantProps<typeof layoutVariants> & { className?: string }>) {
   return (
-    <main className={cn(layoutVariants({ variant }))} {...rest}>
+    <main className={cn(layoutVariants({ variant }), className)} {...props}>
       {children}
     </main>
   );
 }
 
-export function LayoutHeader({ children }: PropsWithChildren) {
-  return <div className="flex flex-row justify-between my-6 px-8">{children}</div>;
+export function LayoutHeader(props: PropsWithChildren<{ className?: string }>) {
+  return (
+    <div className={cn('flex flex-row justify-between my-6 px-8', props.className)}>
+      {props.children}
+    </div>
+  );
 }
 
-export function LayoutTitle({ children }: PropsWithChildren) {
-  return <div className="flex flex-row items-center gap-3 min-h-10">{children}</div>;
+export function LayoutTitle(props: PropsWithChildren<{ className?: string }>) {
+  return (
+    <div className={cn('flex flex-row flex-wrap items-center gap-3 min-h-10', props.className)}>
+      {props.children}
+    </div>
+  );
 }
 
 export function LayoutNavigation({

--- a/webui/src/utils/bundle.ts
+++ b/webui/src/utils/bundle.ts
@@ -8,5 +8,13 @@ export function relativeBundlePath(
   entry: Pick<PartialAtlasEntry, 'projectRoot' | 'sharedRoot'>,
   path: string
 ) {
-  return path.replace((entry.sharedRoot || entry.projectRoot) + '/', '');
+  return path.replace(rootBundlePath(entry) + '/', '');
+}
+
+/**
+ * Get the "shared root" of all paths within the entry.
+ * This is calculated by comparing `projectRoot` and `watchFolders`.
+ */
+export function rootBundlePath(entry: Pick<PartialAtlasEntry, 'projectRoot' | 'sharedRoot'>) {
+  return entry.sharedRoot || entry.projectRoot;
 }

--- a/webui/src/utils/bundle.ts
+++ b/webui/src/utils/bundle.ts
@@ -1,0 +1,12 @@
+import { PartialAtlasEntry } from '~core/data/types';
+
+/**
+ * Translate an absolute path to a relative path, based on the entry's project root.
+ * This is a simple replace operation.
+ */
+export function relativeBundlePath(
+  entry: Pick<PartialAtlasEntry, 'projectRoot' | 'serverRoot'>,
+  path: string
+) {
+  return path.replace((entry.serverRoot || entry.projectRoot) + '/', '');
+}

--- a/webui/src/utils/bundle.ts
+++ b/webui/src/utils/bundle.ts
@@ -5,8 +5,8 @@ import { PartialAtlasEntry } from '~core/data/types';
  * This is a simple replace operation.
  */
 export function relativeBundlePath(
-  entry: Pick<PartialAtlasEntry, 'projectRoot' | 'serverRoot'>,
+  entry: Pick<PartialAtlasEntry, 'projectRoot' | 'sharedRoot'>,
   path: string
 ) {
-  return path.replace((entry.serverRoot || entry.projectRoot) + '/', '');
+  return path.replace((entry.sharedRoot || entry.projectRoot) + '/', '');
 }

--- a/webui/src/utils/entry.ts
+++ b/webui/src/utils/entry.ts
@@ -1,9 +1,0 @@
-import { PartialAtlasEntry } from '~core/data/types';
-
-/**
- * Translate an absolute path to a relative path, based on the entry's project root.
- * This is a simple replace operation.
- */
-export function relativeEntryPath(entry: Pick<PartialAtlasEntry, 'projectRoot'>, path: string) {
-  return path.replace(entry.projectRoot + '/', '');
-}


### PR DESCRIPTION
### Linked issue
This introduces a new property called `sharedRoot`. TL;DR; we need a project root to simplify absolute module paths, both `projectRoot` and `serverRoot` do not reflect this properly for NCL.
