### PR TITLE
refactor: add module IDs and restructure metro config for atlas conversion

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ export function createExpoAtlasMiddleware(config: MetroConfig) {
 
   // @ts-expect-error Should still be writable at this stage
   config.serializer.customSerializer = (entryPoint, preModules, graph, options) => {
-    source.serializeGraph({ projectRoot, entryPoint, preModules, graph, options, metroConfig });
+    source.serializeGraph({ projectRoot, entryPoint, preModules, graph, serializeOptions: options, metroConfig });
     return metroCustomSerializer(entryPoint, preModules, graph, options);
   };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,9 +31,16 @@ export function createExpoAtlasMiddleware(config: MetroConfig) {
   const metroConfig = convertMetroConfig(config);
 
   // @ts-expect-error Should still be writable at this stage
-  config.serializer.customSerializer = (entryPoint, preModules, graph, options) => {
-    source.serializeGraph({ projectRoot, entryPoint, preModules, graph, serializeOptions: options, metroConfig });
-    return metroCustomSerializer(entryPoint, preModules, graph, options);
+  config.serializer.customSerializer = (entryPoint, preModules, graph, serializeOptions) => {
+    source.serializeGraph({
+      projectRoot,
+      entryPoint,
+      preModules,
+      graph,
+      serializeOptions,
+      metroConfig,
+    });
+    return metroCustomSerializer(entryPoint, preModules, graph, serializeOptions);
   };
 
   return { source, middleware, registerMetro };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import type { ConfigT as MetroConfig } from 'metro-config';
 
-import { MetroGraphSource } from './data/MetroGraphSource';
+import { MetroGraphSource, convertMetroConfig } from './data/MetroGraphSource';
 import { createAtlasMiddleware } from './utils/middleware';
 
 /**
@@ -28,23 +28,11 @@ export function createExpoAtlasMiddleware(config: MetroConfig) {
   const registerMetro = source.registerMetro.bind(source);
 
   const metroCustomSerializer = config.serializer?.customSerializer ?? (() => {});
-  const metroExtensions = {
-    source: config.resolver?.sourceExts,
-    asset: config.resolver?.assetExts,
-  };
+  const metroConfig = convertMetroConfig(config);
 
   // @ts-expect-error Should still be writable at this stage
   config.serializer.customSerializer = (entryPoint, preModules, graph, options) => {
-    source.serializeGraph({
-      projectRoot,
-      entryPoint,
-      preModules,
-      graph,
-      options,
-      extensions: metroExtensions,
-      watchFolders: config.watchFolders,
-    });
-
+    source.serializeGraph({ projectRoot, entryPoint, preModules, graph, options, metroConfig });
     return metroCustomSerializer(entryPoint, preModules, graph, options);
   };
 

--- a/src/data/MetroGraphSource.ts
+++ b/src/data/MetroGraphSource.ts
@@ -17,7 +17,7 @@ type ConvertGraphToAtlasOptions = {
   entryPoint: string;
   preModules: Readonly<MetroModule[]>;
   graph: MetroGraph;
-  options: Readonly<metro.SerializerOptions>;
+  serializeOptions: Readonly<metro.SerializerOptions>;
   /** Options passed-through from the Metro config */
   metroConfig: {
     watchFolders?: Readonly<string[]>;
@@ -168,7 +168,10 @@ export function convertGraph(options: ConvertGraphToAtlasOptions): AtlasBundle {
 
 /** Find and collect all dependnecies related to the entrypoint within the graph */
 export function collectEntryPointModules(
-  options: Pick<ConvertGraphToAtlasOptions, 'graph' | 'entryPoint' | 'metroConfig'>
+  options: Pick<
+    ConvertGraphToAtlasOptions,
+    'graph' | 'entryPoint' | 'serializeOptions' | 'metroConfig'
+  >
 ) {
   const modules = new Map<string, AtlasModule>();
 
@@ -186,10 +189,10 @@ export function collectEntryPointModules(
 
 /** Convert a Metro module to a JSON-serializable Atlas module */
 export function convertModule(
-  options: Pick<ConvertGraphToAtlasOptions, 'graph' | 'metroConfig' | 'options'>,
+  options: Pick<ConvertGraphToAtlasOptions, 'graph' | 'metroConfig' | 'serializeOptions'>,
   module: MetroModule
 ): AtlasModule {
-  const { createModuleId } = options.options;
+  const { createModuleId } = options.serializeOptions;
 
   return {
     id: createModuleId(module.path),
@@ -254,11 +257,11 @@ export function convertTransformOptions(
 
 /** Convert Metro serialize options to a JSON-serializable object */
 export function convertSerializeOptions(
-  options: Pick<ConvertGraphToAtlasOptions, 'options'>
+  options: Pick<ConvertGraphToAtlasOptions, 'serializeOptions'>
 ): AtlasBundle['serializeOptions'] {
-  const serializeOptions: AtlasBundle['serializeOptions'] = { ...options.options };
+  const serializeOptions: AtlasBundle['serializeOptions'] = { ...options.serializeOptions };
 
-  // Delete all filters
+  // Delete all non-serializable functions
   delete serializeOptions['processModuleFilter'];
   delete serializeOptions['createModuleId'];
   delete serializeOptions['getRunModuleStatement'];

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -47,6 +47,8 @@ export type AtlasBundleDelta = {
 };
 
 export type AtlasModule = {
+  /** The internal module ID given by Metro */
+  id: number;
   /** The absoluate path of this module */
   path: string;
   /** The name of the package this module belongs to, if from an external package */
@@ -63,4 +65,4 @@ export type AtlasModule = {
   output?: MixedOutput[];
 };
 
-export type AtlasModuleRef = Pick<AtlasModule, 'path' | 'package'>;
+export type AtlasModuleRef = Pick<AtlasModule, 'id' | 'path' | 'package'>;

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -39,14 +39,14 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
   createAtlasFile(atlasFile);
 
   // @ts-expect-error
-  config.serializer.customSerializer = (entryPoint, preModules, graph, options) => {
+  config.serializer.customSerializer = (entryPoint, preModules, graph, serializeOptions) => {
     // Note(cedric): we don't have to await this, it has a built-in write queue
     writeAtlasEntry(
       atlasFile,
-      convertGraph({ projectRoot, entryPoint, preModules, graph, options, metroConfig })
+      convertGraph({ projectRoot, entryPoint, preModules, graph, serializeOptions, metroConfig })
     );
 
-    return originalSerializer(entryPoint, preModules, graph, options);
+    return originalSerializer(entryPoint, preModules, graph, serializeOptions);
   };
 
   return config;

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -1,7 +1,7 @@
 import { type MetroConfig } from 'metro-config';
 
 import { createAtlasFile, getAtlasPath, writeAtlasEntry } from './data/AtlasFileSource';
-import { convertGraph } from './data/MetroGraphSource';
+import { convertGraph, convertMetroConfig } from './data/MetroGraphSource';
 
 type ExpoAtlasOptions = Partial<{
   /** The output of the atlas file, defaults to `.expo/atlas.json` */
@@ -33,11 +33,7 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
   }
 
   const atlasFile = options?.atlasFile ?? getAtlasPath(projectRoot);
-  const watchFolders = config.watchFolders;
-  const extensions = {
-    source: config.resolver?.sourceExts,
-    asset: config.resolver?.assetExts,
-  };
+  const metroConfig = convertMetroConfig(config);
 
   // Note(cedric): we don't have to await this, Metro would never bundle before this is finisheds
   createAtlasFile(atlasFile);
@@ -47,15 +43,7 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
     // Note(cedric): we don't have to await this, it has a built-in write queue
     writeAtlasEntry(
       atlasFile,
-      convertGraph({
-        projectRoot,
-        entryPoint,
-        preModules,
-        graph,
-        options,
-        extensions,
-        watchFolders,
-      })
+      convertGraph({ projectRoot, entryPoint, preModules, graph, options, metroConfig })
     );
 
     return originalSerializer(entryPoint, preModules, graph, options);

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -35,7 +35,7 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
   const atlasFile = options?.atlasFile ?? getAtlasPath(projectRoot);
   const metroConfig = convertMetroConfig(config);
 
-  // Note(cedric): we don't have to await this, Metro would never bundle before this is finisheds
+  // Note(cedric): we don't have to await this, Metro would never bundle before this is finishes
   createAtlasFile(atlasFile);
 
   // @ts-expect-error


### PR DESCRIPTION
### Linked issue
This restructures the fields from Metro config used within the graph conversion process. It also adds the internal module ID used within Metro/final bundle, so users can look them up (note, UI is not implemented for this yet).