### PR TITLE
fix: expose atlas file recreation logic to expo cli

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { MetroGraphSource } from './data/MetroGraphSource';
 export {
   AtlasFileSource,
   createAtlasFile,
+  ensureAtlasFileExist,
   validateAtlasFile,
   getAtlasMetdata,
   getAtlasPath,

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -57,6 +57,10 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
   return config;
 }
 
+/**
+ * Fully reset, or recreate, the Expo Atlas file containing all Metro information.
+ * This method should only be called once per exporting session, to avoid overwriting data with mutliple Metro instances.
+ */
 export async function resetExpoAtlasFile(projectRoot: string) {
   const filePath = getAtlasPath(projectRoot);
   await createAtlasFile(filePath);

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -1,6 +1,11 @@
 import { type MetroConfig } from 'metro-config';
 
-import { ensureAtlasFileExist, getAtlasPath, writeAtlasEntry } from './data/AtlasFileSource';
+import {
+  createAtlasFile,
+  ensureAtlasFileExist,
+  getAtlasPath,
+  writeAtlasEntry,
+} from './data/AtlasFileSource';
 import { convertGraph, convertMetroConfig } from './data/MetroGraphSource';
 
 type ExpoAtlasOptions = Partial<{
@@ -50,4 +55,10 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
   };
 
   return config;
+}
+
+export async function resetExpoAtlasFile(projectRoot: string) {
+  const filePath = getAtlasPath(projectRoot);
+  await createAtlasFile(filePath);
+  return filePath;
 }

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -1,6 +1,6 @@
 import { type MetroConfig } from 'metro-config';
 
-import { createAtlasFile, getAtlasPath, writeAtlasEntry } from './data/AtlasFileSource';
+import { ensureAtlasFileExist, getAtlasPath, writeAtlasEntry } from './data/AtlasFileSource';
 import { convertGraph, convertMetroConfig } from './data/MetroGraphSource';
 
 type ExpoAtlasOptions = Partial<{
@@ -36,7 +36,7 @@ export function withExpoAtlas(config: MetroConfig, options: ExpoAtlasOptions = {
   const metroConfig = convertMetroConfig(config);
 
   // Note(cedric): we don't have to await this, Metro would never bundle before this is finishes
-  createAtlasFile(atlasFile);
+  ensureAtlasFileExist(atlasFile);
 
   // @ts-expect-error
   config.serializer.customSerializer = (entryPoint, preModules, graph, serializeOptions) => {


### PR DESCRIPTION
### Linked issue
The Expo CLI might instantiate Metro multiple times for specialized bundles, like web static exports. This PR exposes a `resetExpoAtlasFile` method for the CLI to only reset this data once, without overwriting previously generated entries within the same export session.
