### PR TITLE
chore: enable metro and tailwind caching in ci

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -44,6 +44,14 @@ jobs:
         with:
           with-webui: true
 
+      - name: ♻️ Setup cache
+        uses: actions/cache@v4
+        with:
+          path: webui/node_modules/.cache
+          key: webui-caches-${{ runner.os }}-${{ hashFiles('webui/bun.lockb') }}
+          restore-keys: |
+            webui-caches-${{ runner.os }}-
+
       # Required for typechecking webui
       - name: 👷 Build core
         run: bun run build

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           with-webui: true
 
-      - name: ♻️ Setup cache
+      - name: ♻️ Setup Metro cache
         uses: actions/cache@v4
         with:
-          path: webui/node_modules/.cache
-          key: webui-caches-${{ runner.os }}-${{ hashFiles('webui/bun.lockb') }}
+          path: webui/node_modules/.cache/metro
+          key: webui-metro-${{ runner.os }}-${{ hashFiles('webui/bun.lockb') }}
           restore-keys: |
-            webui-caches-${{ runner.os }}-
+            webui-metro-${{ runner.os }}-
 
       # Required for typechecking webui
       - name: 👷 Build core


### PR DESCRIPTION
### Linked issue
This might speed up webui builds, especially when used with `EXPO_USE_FAST_RESOLVER`.
