### PR TITLE
chore: update repository links

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "metro.d.ts",
     "webui/dist"
   ],
-  "homepage": "https://github.com/byCedric/expo-atlas",
+  "homepage": "https://github.com/expo/expo-atlas",
   "bugs": {
-    "url": "https://github.com/byCedric/expo-atlas/issues"
+    "url": "https://github.com/expo/expo-atlas/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/byCedric/expo-atlas"
+    "url": "https://github.com/expo/expo-atlas"
   },
   "scripts": {
     "build": "expo-module build",


### PR DESCRIPTION
Updating these links because the repository has changed.