### PR TITLE
fix: expose Atlas export write queue to prevent exit

### DIFF
--- a/src/data/AtlasFileSource.ts
+++ b/src/data/AtlasFileSource.ts
@@ -83,6 +83,15 @@ export async function readAtlasEntry(filePath: string, id: number): Promise<Atla
 let writeQueue: Promise<any> = Promise.resolve();
 
 /**
+ * Wait until the Atlas file has all data written.
+ * Note, this is a workaround whenever `process.exit` is required, avoid if possible.
+ * @internal
+ */
+export function waitUntilAtlasFileReady() {
+  return writeQueue;
+}
+
+/**
  * Add a new entry to the Atlas file.
  * This function also ensures the Atlas file is ready to be written to, due to complications with Expo CLI.
  * Eventually, the entry is appended on a new line, so we can load them selectively.

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -8,6 +8,8 @@ import {
 } from './data/AtlasFileSource';
 import { convertGraph, convertMetroConfig } from './data/MetroGraphSource';
 
+export { waitUntilAtlasFileReady } from './data/AtlasFileSource';
+
 type ExpoAtlasOptions = Partial<{
   /** The output of the atlas file, defaults to `.expo/atlas.json` */
   atlasFile: string;


### PR DESCRIPTION
This is a workaround and should be avoided as much as possible.