### PR TITLE
refactor(webui): avoid importing `expo-router` in API routes

### DIFF
--- a/webui/src/app/(atlas)/[bundle].tsx
+++ b/webui/src/app/(atlas)/[bundle].tsx
@@ -11,11 +11,12 @@ import {
   NoDataState,
   NoDataWithFiltersState,
 } from '~/components/StateInfo';
+import { useModuleFilters } from '~/hooks/useModuleFilters';
 import { BundleDeltaToast, useBundle } from '~/providers/bundle';
 import { Layout, LayoutHeader, LayoutNavigation, LayoutTitle } from '~/ui/Layout';
 import { Tag } from '~/ui/Tag';
 import { fetchApi, handleApiError } from '~/utils/api';
-import { type ModuleFilters, moduleFiltersToParams, useModuleFilters } from '~/utils/filters';
+import { type ModuleFilters, moduleFiltersToParams } from '~/utils/filters';
 import { formatFileSize } from '~/utils/formatString';
 
 export default function BundlePage() {

--- a/webui/src/app/(atlas)/[bundle]/folders/[path].tsx
+++ b/webui/src/app/(atlas)/[bundle]/folders/[path].tsx
@@ -13,11 +13,12 @@ import {
   NoDataState,
   NoDataWithFiltersState,
 } from '~/components/StateInfo';
+import { useModuleFilters } from '~/hooks/useModuleFilters';
 import { BundleDeltaToast, useBundle } from '~/providers/bundle';
 import { Layout, LayoutHeader, LayoutNavigation, LayoutTitle } from '~/ui/Layout';
 import { Tag } from '~/ui/Tag';
 import { fetchApi, handleApiError } from '~/utils/api';
-import { type ModuleFilters, useModuleFilters, moduleFiltersToParams } from '~/utils/filters';
+import { type ModuleFilters, moduleFiltersToParams } from '~/utils/filters';
 import { formatFileSize } from '~/utils/formatString';
 
 export default function FolderPage() {

--- a/webui/src/components/ModuleFilterForm.tsx
+++ b/webui/src/components/ModuleFilterForm.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import { type FormEvent, type KeyboardEvent, useState, useCallback } from 'react';
 
+import { useModuleFilters } from '~/hooks/useModuleFilters';
 import { Button } from '~/ui/Button';
 import { Checkbox } from '~/ui/Checkbox';
 import { Input } from '~/ui/Input';
@@ -14,7 +15,6 @@ import {
   SheetTrigger,
 } from '~/ui/Sheet';
 import { debounce } from '~/utils/debounce';
-import { useModuleFilters } from '~/utils/filters';
 
 type ModuleFiltersFormProps = {
   disableNodeModules?: boolean;

--- a/webui/src/hooks/useModuleFilters.ts
+++ b/webui/src/hooks/useModuleFilters.ts
@@ -1,0 +1,17 @@
+import { useGlobalSearchParams, useRouter } from 'expo-router';
+
+import { DEFAULT_FILTERS, type ModuleFilters } from '~/utils/filters';
+
+/**
+ * Get the current module filters from URL search params, using Expo Router.
+ * This returns the filters, with default values, and if any of the filters has been defined.
+ */
+export function useModuleFilters() {
+  const router = useRouter();
+  const filters = useGlobalSearchParams<ModuleFilters>();
+  return {
+    filters,
+    filtersEnabled: !!filters.scope || !!filters.include || !!filters.exclude,
+    resetFilters: () => router.setParams(DEFAULT_FILTERS),
+  };
+}

--- a/webui/src/utils/filters.ts
+++ b/webui/src/utils/filters.ts
@@ -1,4 +1,3 @@
-import { useGlobalSearchParams, useRouter } from 'expo-router';
 import picomatch from 'picomatch';
 
 import { type AtlasModule } from '~core/data/types';
@@ -46,20 +45,6 @@ export function moduleFiltersToParams(filters: ModuleFilters) {
   if (filters.exclude) params.set('exclude', filters.exclude);
 
   return params;
-}
-
-/**
- * Get the current module filters from URL search params, using Expo Router.
- * This returns the filters, with default values, and if any of the filters has been defined.
- */
-export function useModuleFilters() {
-  const router = useRouter();
-  const filters = useGlobalSearchParams<ModuleFilters>();
-  return {
-    filters,
-    filtersEnabled: !!filters.scope || !!filters.include || !!filters.exclude,
-    resetFilters: () => router.setParams(DEFAULT_FILTERS),
-  };
 }
 
 /** Filter the modules based on the filters, and an optional (root) path. */


### PR DESCRIPTION
This should reduce the overall packed tarball by roughly 4mb, removing `expo-router` (and therefore also `@react-navigation` and `react-native`) from 2 API routes.

Atlas can be useful for Atlas itself 😬