### PR TITLE
fix(webui): link to proper path when filtering single results in bundle graph

### DIFF
--- a/webui/src/components/BundleGraph.tsx
+++ b/webui/src/components/BundleGraph.tsx
@@ -49,7 +49,7 @@ export function BundleGraph(props: BundleGraphProps) {
       onEvents={{
         click({ event, data }: { event: any; data: TreemapNode }) {
           if (event.event.altKey || event.event.ctrlKey || event.event.metaKey) {
-            const path = data.value === 100 ? data.name : data.moduleRelativePath;
+            const path = data.moduleRelativePath;
 
             router.push({
               pathname: !path


### PR DESCRIPTION
This is an old issue, originating from the treegraph not knowing the path (and basing it on the node names). Now, we actually keep the proper absolute/relative paths in the nodes too.

When filtering results in the bundle graph to a single item (e.g. `event-target-shim`), it wouldn't link properly to the right folder (note, it's always using push, so there is likely an expo router issue in here too). 