### PR TITLE
docs: fix typo in docs for prod command (no-minify becomes minify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ EXPO_UNSTABLE_ATLAS=true npx expo start
 ```
 
 > [!TIP]
-> Expo start runs in development mode by default. If you want to see a production bundle of your app, you can start the local dev server in production mode: `$ expo start --no-dev --no-minify`.
+> Expo start runs in development mode by default. If you want to see a production bundle of your app, you can start the local dev server in production mode: `$ expo start --no-dev --minify`.
 
 ### Using `$ expo export`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ EXPO_UNSTABLE_ATLAS=true npx expo start
 ```
 
 > [!TIP]
-> Expo start runs in development mode by default. If you want to see a production bundle of your app, you can start the local dev server in production mode: `$ expo start --no-dev --minify`.
+> Expo start runs in development mode by default. If you want to see a production bundle of your app, you can start the local dev server in production mode: `$ expo start --no-dev`.
 
 ### Using `$ expo export`
 


### PR DESCRIPTION
looks like a typo, there's no `--no-minify`