### PR TITLE
feature: add preliminary support for dom components

### DIFF
--- a/packages/expo-atlas-ui/components/BundleTag.tsx
+++ b/packages/expo-atlas-ui/components/BundleTag.tsx
@@ -18,6 +18,7 @@ const bundleTagVariants = cva('', {
     } satisfies Record<AtlasBundle['platform'], string>,
     environment: {
       client: '',
+      dom: 'bg-palette-blue3',
       node: 'bg-palette-orange3',
       'react-server': 'bg-palette-orange3',
     } satisfies Record<AtlasBundle['environment'], string>,
@@ -71,6 +72,9 @@ export function BundleTag({ className, platform, environment, ...props }: Bundel
             <li className="inline-flex items-center gap-1">
               <EnvironmentIcon environment="client" size={14} /> Client — Bundles that run on
               device.
+            </li>
+            <li className="inline-flex items-center gap-1">
+              <EnvironmentIcon environment="dom" size={14} /> DOM — Webview embedded components.
             </li>
             <li className="inline-flex items-center gap-1">
               <EnvironmentIcon environment="node" size={14} /> SSR — Bundles that only run on

--- a/packages/expo-atlas-ui/components/EnvironmentIcon.tsx
+++ b/packages/expo-atlas-ui/components/EnvironmentIcon.tsx
@@ -10,6 +10,7 @@ type EnvironmentIconProps = Omit<
 
 const iconsByEnvironment: Record<AtlasBundle['environment'], any> = {
   client: require('lucide-react/dist/esm/icons/tablet-smartphone').default,
+  dom: require('lucide-react/dist/esm/icons/globe').default,
   node: require('lucide-react/dist/esm/icons/hexagon').default,
   'react-server': require('lucide-react/dist/esm/icons/server').default,
 };

--- a/packages/expo-atlas-ui/components/EnvironmentIcon.tsx
+++ b/packages/expo-atlas-ui/components/EnvironmentIcon.tsx
@@ -10,7 +10,7 @@ type EnvironmentIconProps = Omit<
 
 const iconsByEnvironment: Record<AtlasBundle['environment'], any> = {
   client: require('lucide-react/dist/esm/icons/tablet-smartphone').default,
-  dom: require('lucide-react/dist/esm/icons/globe').default,
+  dom: require('lucide-react/dist/esm/icons/panel-top').default,
   node: require('lucide-react/dist/esm/icons/hexagon').default,
   'react-server': require('lucide-react/dist/esm/icons/server').default,
 };

--- a/packages/expo-atlas-ui/components/EnvironmentName.tsx
+++ b/packages/expo-atlas-ui/components/EnvironmentName.tsx
@@ -8,6 +8,7 @@ type EnvironmentNameProps = PropsWithChildren<{
 
 export const environmentNames: Record<AtlasBundle['environment'], string> = {
   client: 'Client',
+  dom: 'DOM',
   node: 'SSR',
   'react-server': 'RSC',
 };

--- a/packages/expo-atlas/src/data/types.ts
+++ b/packages/expo-atlas/src/data/types.ts
@@ -21,7 +21,7 @@ export type AtlasBundle = {
   /** The platform for which the bundle was created */
   platform: 'android' | 'ios' | 'web' | 'unknown';
   /** The environment this bundle is compiled for */
-  environment: 'client' | 'node' | 'react-server';
+  environment: 'client' | 'dom' | 'node' | 'react-server';
   /** The absolute path to the root of the project */
   projectRoot: string;
   /** The absolute path to the shared root of all imported modules */


### PR DESCRIPTION
This resolves an issue with the `entryPoint` being overwritten to `_expo/@dom/<hash>`. It uses the `transformOptions.platform === 'web' && !!transformOptions.customTransformOptions.dom` to determine if a graph is related to a dom route. Once it is, it uses `path.join(options.entryPoint, transformOptions.customTransformOptions.dom)` as entry point.