### PR TITLE
fix(cli): count preloaded modules in bundle size and use decimal system for file size

### DIFF
--- a/packages/expo-atlas-ui/app/--/bundles/[bundle]/modules/graph+api.ts
+++ b/packages/expo-atlas-ui/app/--/bundles/[bundle]/modules/graph+api.ts
@@ -37,8 +37,10 @@ export async function GET(request: Request, params: Record<'bundle', string>) {
     data: finalizeModuleTree(createModuleTree(bundle, filteredModules)),
     bundle: {
       platform: bundle.platform as any,
-      moduleSize: allModules.reduce((size, module) => size + module.size, 0),
-      moduleFiles: bundle.modules.size,
+      moduleFiles: bundle.modules.size + bundle.runtimeModules.length,
+      moduleSize: allModules
+        .concat(bundle.runtimeModules)
+        .reduce((size, module) => size + module.size, 0),
     },
     filtered: {
       moduleSize: filteredModules.reduce((size, module) => size + module.size, 0),

--- a/packages/expo-atlas-ui/app/--/bundles/[bundle]/modules/index+api.ts
+++ b/packages/expo-atlas-ui/app/--/bundles/[bundle]/modules/index+api.ts
@@ -44,8 +44,10 @@ export async function GET(request: Request, params: Record<'bundle', string>) {
     })),
     bundle: {
       platform: bundle.platform as any,
-      moduleSize: allModules.reduce((size, module) => size + module.size, 0),
-      moduleFiles: bundle.modules.size,
+      moduleFiles: bundle.modules.size + bundle.runtimeModules.length,
+      moduleSize: allModules
+        .concat(bundle.runtimeModules)
+        .reduce((size, module) => size + module.size, 0),
     },
     filtered: {
       moduleSize: filteredModules.reduce((size, module) => size + module.size, 0),

--- a/packages/expo-atlas-ui/components/FileSize.tsx
+++ b/packages/expo-atlas-ui/components/FileSize.tsx
@@ -40,13 +40,16 @@ export function FileSize(props: BundleFileSizeProps) {
   );
 }
 
-/** Format files or bundle size, from bytes to the nearest unit */
-export function formatByteSize(size: number) {
-  if (size < 1024) {
-    return size + 'B';
-  } else if (size < 1024 * 1024) {
-    return (size / 1024).toFixed(1) + 'KB';
+/**
+ * Format files or bundle size, from bytes to the nearest unit.
+ * This uses the decimal system with a scaling factor of `1000`.
+ */
+export function formatByteSize(byteSize: number, scalingFactor = 1000) {
+  if (byteSize < scalingFactor) {
+    return byteSize + 'B';
+  } else if (byteSize < scalingFactor * scalingFactor) {
+    return (byteSize / scalingFactor).toFixed(1) + 'KB';
   } else {
-    return (size / 1024 / 1024).toFixed(1) + 'MB';
+    return (byteSize / scalingFactor / scalingFactor).toFixed(1) + 'MB';
   }
 }


### PR DESCRIPTION
This should clear out the remaining skew in bundle size. Unfortunately, the prelude modules (virtual modules, and modules from `runBeforeMainModule`) are not visible in the bundle graph yet.